### PR TITLE
Day 1 - Twitter auth + sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# please add general patterns to your global ignore list
+# see https://github.com/github/gitignore#readme
+.env
+.DS_STORE
+*.swp
+*.rbc
+/pkg
+/Gemfile.lock
+/coverage
+.yardoc
+/doc
+.bundle
+vendor

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,9 @@
+# Gemfile
+source "https://rubygems.org"
+gem "sinatra"
+gem "oauth"
+gem 'twitter'
+gem "pg"    # for Postgres
+gem "rake"  # so we can run Rake tasks
+gem "sinatra-activerecord"    # for Active Record models
+gem 'dotenv'

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,4 @@
+# Rakefile
+require 'sinatra/activerecord'
+require 'sinatra/activerecord/rake'
+require './app'

--- a/app.rb
+++ b/app.rb
@@ -1,0 +1,163 @@
+require 'dotenv'
+require 'rubygems'
+require 'sinatra'
+require 'sinatra/activerecord'
+require './config/environment'
+require 'oauth'
+require 'json'
+require 'twitter'
+
+Dotenv.load()
+
+class App < Sinatra::Base
+
+  SERVER_HOST = '0.0.0.0'
+  SERVER_PORT = '3000'
+  BASE_URL    = "https://93cf-2600-1700-9e20-ba0-a57f-5756-a2b6-c16.ngrok.io"
+
+  TWITTER_KEY           = ENV['TWITTER_KEY']
+  TWITTER_SECRET        = ENV['TWITTER_SECRET']
+  TWITTER_OAUTH2_KEY     = ENV['TWITTER_OAUTH_KEY']
+  TWITTER_OAUTH2_SECRET  = ENV['TWITTER_OAUTH_SECRET']
+
+  TWITTER_CALLBACK = "#{BASE_URL}/auth/twitter/callback"
+
+  GITHUB_KEY      = ''
+  GITHUB_SECRET   = ''
+  GITHUB_CALLBACK = "#{BASE_URL}/auth/github/callback" 
+
+  # Sinatra settings
+  enable :sessions
+
+  set :bind, SERVER_HOST
+  set :port, SERVER_PORT
+
+  set :static, false
+  set :run, true
+
+  get '/' do
+    erb :index
+  end
+
+  # Twitter
+
+  get '/auth/twitter' do
+    oauth = OAuth::Consumer.new(
+      TWITTER_KEY,
+      TWITTER_SECRET,  
+      :site => 'https://api.twitter.com',
+      :scheme => :header,
+      :http_method => :post,
+      :request_token_path => "/oauth/request_token",
+      :access_token_path => "/oauth/access_token",
+      :authorize_path => "/oauth/authorize"
+    )
+    request_token            = oauth.get_request_token :oauth_callback => TWITTER_CALLBACK
+    session[:twitter_token]  = request_token.token
+    session[:twitter_secret] = request_token.secret
+
+    puts "Token/Secret: #{request_token.token} / #{request_token.secret}"
+
+    redirect request_token.authorize_url
+  end
+
+  get '/:username/sync' do
+    forced = params[:force] == 'true'
+    u = User.find_by(twitter_username: params[:username])
+
+    client = Twitter::REST::Client.new do |config|
+      config.consumer_key        = TWITTER_KEY
+      config.consumer_secret     = TWITTER_SECRET
+      config.access_token        = u.twitter_access_token
+      config.access_token_secret = u.twitter_token_secret
+    end
+    
+    begin
+      query = "from:#{u.twitter_username} since:2023-03-07 exclude:replies exclude:retweets"
+      puts "Fetching recent tweets: #{query}\n\n"
+      errors = []
+      @tweets = client.search(query, result_type: "recent")
+
+      @tweets.each do |tweet|
+        puts tweet.attrs.as_json(except: :user)
+        post = u.posts.find_or_initialize_by(provider: 'twitter', provider_id: tweet.id) do |p|
+          p.body = tweet.text
+          p.posted_at = tweet.created_at
+        end
+        post.provider_post_raw = tweet.attrs.as_json
+        post_saved = post.save
+        puts "Saving post: #{post_saved}\n\n"
+        errors << post.errors if !post_saved
+      end
+
+      u.twitter_last_synced_at = DateTime.current
+      u.twitter_last_error = { errors_at: DateTime.current, errors: errors }.as_json if errors.count > 0
+      u.save
+
+      if forced
+        session[:twitter_forced] = true
+      end
+
+      #erb :sync
+      redirect "/?errors=#{errors.count > 0}"
+    rescue Twitter::Error::TooManyRequests => error
+      # NOTE: Your process could go to sleep for up to 15 minutes but if you
+      # retry any sooner, it will almost certainly fail with the same exception.
+      sleep error.rate_limit.reset_in + 1
+      retry
+    end
+  end
+
+  get '/auth/twitter/callback' do
+    oauth = OAuth::Consumer.new(
+      TWITTER_KEY,
+      TWITTER_SECRET,  
+      :site => 'https://api.twitter.com',
+      :scheme => :header,
+      :http_method => :post,
+      :request_token_path => "/oauth/request_token",
+      :access_token_path => "/oauth/access_token",
+      :authorize_path => "/oauth/authorize"
+    )
+
+    request_token = OAuth::RequestToken.new(oauth, session[:twitter_token], session[:twitter_secret])
+
+    access_token = oauth.get_access_token(request_token, :oauth_verifier => params[:oauth_verifier])
+
+    puts "Access token: #{access_token.inspect}"
+
+    oauth = OAuth::Consumer.new(TWITTER_KEY, TWITTER_SECRET, { :site => 'https://api.twitter.com'})
+
+    response = oauth.request(:get, '/1.1/account/verify_credentials.json', access_token, { :scheme => :query_string })
+    
+    response_json = JSON.parse(response.body)
+
+    user = User.find_or_initialize_by(name: response_json["name"]) do |u|
+      u.avatar_url = response_json["profile_image_url_https"].gsub("_normal", '')
+      u.twitter_id = response_json["id"]
+      u.twitter_username = response_json["screen_name"]
+    end
+    user.twitter_access_token = access_token.token
+    user.twitter_token_secret = access_token.secret
+    user.twitter_profile_raw = response.body
+
+    puts response_json.inspect
+
+    if user.save
+      session[:twitter] = user.twitter_username
+      redirect "/#{user.twitter_username}/sync"
+    else
+      "failed to create user account!"
+    end
+  end
+
+  # Github
+
+  get '/auth/github' do
+      # ...
+    end
+
+  get '/auth/github/callback' do
+    # ...
+  end
+end

--- a/config.ru
+++ b/config.ru
@@ -1,0 +1,2 @@
+require_relative "app"
+run App

--- a/config/database.rb
+++ b/config/database.rb
@@ -1,0 +1,16 @@
+ # in config/database.rb
+ # set the database based on the current environment
+ # The name in the below line is because my main app controller class in app.rb
+database_name = "bipf-leaderboard-#{App.environment}"
+db = URI.parse( ENV['DATABASE_URL'] || "postgres://localhost/#{database_name}")
+
+ # connect ActiveRecord with the current database
+ActiveRecord::Base.establish_connection(
+ :adapter => db.scheme == "postgres" ? "postgresql" : db.scheme,
+ :host => db.host,
+ :port => db.port,
+ :username => db.user,
+ :password => db.password,
+ :database => "#{database_name}",
+ :encoding => "utf8"
+)

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,0 +1,13 @@
+development:
+  adapter: postgresql
+  encoding: unicode
+  database: bipf-leaderboard-development
+  pool: 2
+production:
+  adapter: postgresql
+  encoding: unicode
+  pool: 5
+  host: <%= ENV['DATABASE_HOST'] %>
+  database: <%= ENV['DATABASE_NAME'] %>
+  username: <%= ENV['DATABASE_USER'] %>
+  password: <%= ENV['DATABASE_PASSWORD'] %>

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -1,0 +1,28 @@
+ # in config/environment.rb
+ # get the path of the root of the app
+ # assuming that this file is one folder down in config/
+APP_ROOT = File.expand_path("..", __dir__)
+
+ # require the controller(s)
+ # says that app.rb is in the root
+Dir.glob(File.join(APP_ROOT, "app", "*.rb")).each { |file| require file }
+
+ # require the model(s)
+ # models stored in lib/
+Dir.glob(File.join(APP_ROOT, "lib", "*.rb")).each { |file| require file }
+
+# configure settings
+# This bit of config could also be done in the main app class definition
+# This is monkey-patching onto the main class definition
+# I suppose it's neater to move it here
+# The public/ folder is where images and stylesheets should be, the last line confirms that location
+class App < Sinatra::Base
+ set :method_override, true
+ set :root, APP_ROOT
+ set :views, File.join(APP_ROOT, "views")
+ set :public_folder, File.join(APP_ROOT, "public")
+end
+
+# require database configurations
+# the database setup files that were just made in config/
+require File.join(APP_ROOT, "config", "database")

--- a/db/migrate/20230309195041_create_users.rb
+++ b/db/migrate/20230309195041_create_users.rb
@@ -1,0 +1,19 @@
+class CreateUsers < ActiveRecord::Migration[7.0]
+  def change
+    create_table :users do |t|
+      t.string :name, null: false, default: ""
+      t.string :avatar_url
+      t.string :twitter_id
+      t.string :twitter_username
+      t.string :twitter_access_token
+      t.string :twitter_token_secret
+      t.datetime :twitter_last_synced_at
+      t.text :twitter_last_error
+      t.text :twitter_profile_raw
+
+      t.timestamps
+    end
+
+    add_index :users, :name, unique: true
+  end
+end

--- a/db/migrate/20230310021918_create_posts.rb
+++ b/db/migrate/20230310021918_create_posts.rb
@@ -1,0 +1,16 @@
+class CreatePosts < ActiveRecord::Migration[7.0]
+  def change
+    create_table :posts do |t|
+      t.references :user, foreign_key: true
+      t.string :provider, null: false, default: "twitter"
+      t.string :provider_id
+      t.string :body
+      t.string :posted_at
+      t.text :provider_post_raw
+
+      t.timestamps
+    end
+
+    add_index :posts, [:provider, :provider_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,46 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[7.0].define(version: 2023_03_10_021918) do
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "posts", force: :cascade do |t|
+    t.bigint "user_id"
+    t.string "provider", default: "twitter", null: false
+    t.string "provider_id"
+    t.string "body"
+    t.string "posted_at"
+    t.text "provider_post_raw"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["provider", "provider_id"], name: "index_posts_on_provider_and_provider_id", unique: true
+    t.index ["user_id"], name: "index_posts_on_user_id"
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.string "name", default: "", null: false
+    t.string "avatar_url"
+    t.string "twitter_id"
+    t.string "twitter_username"
+    t.string "twitter_access_token"
+    t.string "twitter_token_secret"
+    t.datetime "twitter_last_synced_at"
+    t.text "twitter_last_error"
+    t.text "twitter_profile_raw"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_users_on_name", unique: true
+  end
+
+  add_foreign_key "posts", "users"
+end

--- a/lib/post.rb
+++ b/lib/post.rb
@@ -1,0 +1,3 @@
+class Post < ActiveRecord::Base
+  belongs_to :user
+end

--- a/lib/user.rb
+++ b/lib/user.rb
@@ -1,0 +1,3 @@
+class User < ActiveRecord::Base
+  has_many :posts
+end

--- a/views/index.erb
+++ b/views/index.erb
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>BIPF - Post Leaderboard</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+  </head>
+  <body>
+
+    <div class="px-4 sm:px-6 lg:px-8 max-w-3xl mx-auto my-10">
+      <div class="sm:flex sm:items-center">
+        <div class="sm:flex-auto">
+          <h1 class="text-base font-semibold leading-6 text-gray-900">BIPF Leaderboard</h1>
+          <p class="mt-2 text-sm text-gray-700">A list of all the current BIPF fellows that are participating in the weekly challenge.</p>
+        </div>
+        <div class="mt-4 sm:mt-0 sm:ml-16 sm:flex-none">
+          <% if session[:twitter] %>
+          <span class="text-sm text-gray-900">Logged in: @<%= session[:twitter] %></span>
+          <% elsif params[:login].present? %>
+          <a href='/auth/twitter' class="block rounded-md bg-indigo-600 py-2 px-3 text-center text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">Login with Twitter</a>
+          <% end %>
+        </div>
+      </div>
+      <div class="mt-8 flow-root">
+        <div class="-my-2 -mx-4 overflow-x-auto sm:-mx-6 lg:-mx-8">
+          <div class="inline-block min-w-full py-2 align-middle sm:px-6 lg:px-8">
+            <table class="min-w-full divide-y divide-gray-300">
+              <thead>
+                <tr>
+                  <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-0">Name</th>
+                  <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Total Tweets Shipped</th>
+                  <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">LinkedIn Posts Shipped</th>
+                  <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Streak</th>
+                </tr>
+              </thead>
+              <tbody class="divide-y divide-gray-200 bg-white">
+                <% User.all.each do |u| %>
+                <tr>
+                  <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm sm:pl-0">
+                    <div class="flex items-center">
+                      <div class="h-10 w-10 flex-shrink-0">
+                        <img class="h-10 w-10 rounded-full" src="<%= u.avatar_url %>" alt="">
+                      </div>
+                      <div class="ml-4">
+                        <div class="font-medium text-gray-900">
+                          <%= u.name %>
+                        </div>
+                        <div class="text-gray-500">
+                          
+                          <a href="https://twitter.com/<%= u.twitter_username %>">
+                            <svg viewBox="0 0 20 20" aria-hidden="true" class="h-5 w-5 fill-slate-400"><path d="M6.29 18.251c7.547 0 11.675-6.253 11.675-11.675 0-.178 0-.355-.012-.53A8.348 8.348 0 0 0 20 3.92a8.19 8.19 0 0 1-2.357.646 4.118 4.118 0 0 0 1.804-2.27 8.224 8.224 0 0 1-2.605.996 4.107 4.107 0 0 0-6.993 3.743 11.65 11.65 0 0 1-8.457-4.287 4.106 4.106 0 0 0 1.27 5.477A4.073 4.073 0 0 1 .8 7.713v.052a4.105 4.105 0 0 0 3.292 4.022 4.095 4.095 0 0 1-1.853.07 4.108 4.108 0 0 0 3.834 2.85A8.233 8.233 0 0 1 0 16.407a11.615 11.615 0 0 0 6.29 1.84"></path></svg>
+                          </a>
+
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
+                    <div class="text-gray-900">
+                      <a href="https://twitter.com/<%= u.twitter_username %>"><%= u.posts.count %></a>
+                      <% if session[:twitter] && session[:twitter_forced] != true %>
+                      <a href="/<%= session[:twitter] %>/sync?force=true">(force sync)</a>
+                      <% end %>
+                    </div>
+                  </td>
+                  <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
+                    <div class="text-gray-900">Coming Soon</div>
+                  </td>
+                  <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
+                    <div class="text-gray-900">Coming Soon</div>
+                  </td>
+                </tr>
+                <% end %>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+
+  </body>
+</html>

--- a/views/sync.erb
+++ b/views/sync.erb
@@ -1,0 +1,3 @@
+<% @tweets.each do |tweet| %>
+  <p><%= tweet.created_at %> - <%= tweet.text %></p>
+<% end %>


### PR DESCRIPTION
Tasks Completed on 2023-03-09
- [x] Basic Sinatra app that displays a simple Tailwind table of auth'd users
- [x] User Twitter authentication
- [x] User Twitter account syncing after authentication
- [x] Added a force sync for logged in users for their own account

<img width="772" alt="Screen Shot 2023-03-09 at 9 19 53 PM" src="https://user-images.githubusercontent.com/432526/224374519-a04b219d-38e6-40a1-b0c2-6c133d8fe909.png">


Blockers:
- Twitter OAuth1 was tricker but figured it out. Think I have to apply for access to webhooks
- LinkedIn requires a "page" to create an account


Resources used:
- https://gist.github.com/bdryanovski/4547000
- https://medium.com/@dmccoy/deploying-a-simple-sinatra-app-with-postgres-to-heroku-c4a883d3f19e
- https://github.com/sferik/twitter
- https://www.mirandawilson.tech/blog/2021/02/01/walkthrough-chitter-orm/